### PR TITLE
Add universal back navigation

### DIFF
--- a/src/hardware/ir_listener.py
+++ b/src/hardware/ir_listener.py
@@ -97,7 +97,7 @@ def process_key(key, current_mode):
 
 
     
-    elif key == "KEY_BACK":
+    elif key in ["KEY_BACK", "KEY_EXIT", "KEY_RETURN"]:
         send_command("back")
 
     elif key == "KEY_POWER":

--- a/src/hardware/rotary_button.py
+++ b/src/hardware/rotary_button.py
@@ -1,0 +1,19 @@
+import RPi.GPIO as GPIO
+import time
+
+class RotaryButton:
+    def __init__(self, pin, mode_manager):
+        self.pin = pin
+        self.mode_manager = mode_manager
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        GPIO.add_event_detect(self.pin, GPIO.FALLING, callback=self._pressed, bouncetime=200)
+
+    def _pressed(self, channel):
+        # Only trigger back when a menu is active
+        if self.mode_manager.get_mode() in self.mode_manager.menu_modes:
+            self.mode_manager.back()
+
+    def cleanup(self):
+        GPIO.remove_event_detect(self.pin)
+        GPIO.cleanup(self.pin)

--- a/src/managers/base_manager.py
+++ b/src/managers/base_manager.py
@@ -57,3 +57,9 @@ class BaseManager(ABC):
     def clear_display(self):
         self.display_manager.clear_screen()
         self.logger.info("Cleared the display screen.")
+
+    def back(self):
+        """Default back action - delegate to ModeManager."""
+        self.logger.debug("BaseManager: Delegating back action to ModeManager.")
+        if self.mode_manager:
+            self.mode_manager.back()

--- a/src/managers/menus/base_manager.py
+++ b/src/managers/menus/base_manager.py
@@ -57,3 +57,9 @@ class BaseManager(ABC):
     def clear_display(self):
         self.display_manager.clear_screen()
         self.logger.info("Cleared the display screen.")
+
+    def back(self):
+        """Default back action - delegate to ModeManager."""
+        self.logger.debug("BaseManager: Delegating back action to ModeManager.")
+        if self.mode_manager:
+            self.mode_manager.back()

--- a/src/managers/menus/clock_menu.py
+++ b/src/managers/menus/clock_menu.py
@@ -172,7 +172,7 @@ class ClockMenu(BaseManager):
                 # Return to Display Menu
                 self.logger.info("ClockMenu: 'Back' => to Display Menu")
                 self.stop_mode()
-                self.mode_manager.to_displaymenu()
+                self.mode_manager.back()
 
             else:
                 self.logger.warning(f"ClockMenu: Unknown main item => {selected}")

--- a/src/managers/menus/config_menu.py
+++ b/src/managers/menus/config_menu.py
@@ -175,6 +175,6 @@ class ConfigMenu(BaseManager):
         elif selected == "IRremote":
             self.mode_manager.to_remotemenu()
         elif selected == "Back":
-            self.mode_manager.to_menu()
+            self.mode_manager.back()
         else:
             self.logger.warning(f"ConfigMenu: Unrecognised selection: {selected}")

--- a/src/managers/menus/display_menu.py
+++ b/src/managers/menus/display_menu.py
@@ -168,9 +168,9 @@ class DisplayMenu(BaseManager):
                 self._display_current_menu()
 
             elif selected_item == "Back":
-                # Return to config menu
+                # Return to previous menu
                 self.stop_mode()
-                self.mode_manager.to_configmenu()
+                self.mode_manager.back()
             else:
                 self.logger.warning(f"DisplayMenu: Unknown main item => {selected_item}")
 

--- a/src/managers/menus/library_manager.py
+++ b/src/managers/menus/library_manager.py
@@ -188,6 +188,8 @@ class LibraryManager(BaseManager):
                 }
                 for item in items
             ]
+            # Append a Back option for consistent navigation
+            self.current_menu_items.append({"title": "Back", "action": "back"})
 
             self.logger.info(f"LibraryManager: Fetched {len(self.current_menu_items)} items for URI: {uri}")
             if self.is_active:
@@ -565,6 +567,14 @@ class LibraryManager(BaseManager):
         else:
             self.logger.info("LibraryManager: Already at root level, cannot go back.")
             self.stop_mode()  # Optionally exit the mode if at root
+
+    def back(self):
+        """Public back interface used by ModeManager or UI."""
+        if self.menu_stack:
+            self.go_back()
+        else:
+            self.stop_mode()
+            super().back()
             
 
     def update_song_info(self, state):

--- a/src/managers/menus/motherearth_manager.py
+++ b/src/managers/menus/motherearth_manager.py
@@ -357,3 +357,8 @@ class MotherEarthManager(BaseManager):
         except Exception as e:
             self.logger.exception(f"MotherEarthManager: Failed to play station - {e}")
             self.display_error_message("Playback Error", f"Could not play station: {e}")
+
+    def back(self):
+        """Exit this manager and return to the previous mode."""
+        self.stop_mode()
+        super().back()

--- a/src/managers/menus/playlist_manager.py
+++ b/src/managers/menus/playlist_manager.py
@@ -154,6 +154,7 @@ class PlaylistManager(BaseManager):
             }
             for item in combined_items
         ]
+        self.current_menu_items.append({"title": "Back", "action": "back"})
 
         self.logger.info(f"PlaylistManager: Updated menu with {len(self.current_menu_items)} items.")
         if self.is_active:
@@ -236,6 +237,9 @@ class PlaylistManager(BaseManager):
             return
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"PlaylistManager: Selected item: {selected_item}")
+        if selected_item.get("action") == "back":
+            self.back()
+            return
         name = selected_item.get("title")
         if not name:
             self.logger.warning("PlaylistManager: Selected item has no name.")
@@ -313,3 +317,8 @@ class PlaylistManager(BaseManager):
         bitdepth = state.get("bitdepth", "Unknown Bit Depth")
         volume = state.get("volume", "Unknown Volume")
         self.logger.info(f"Sample Rate: {sample_rate}, Bit Depth: {bitdepth}, Volume: {volume}")
+
+    def back(self):
+        """Return to the previous menu via ModeManager."""
+        self.stop_mode()
+        super().back()

--- a/src/managers/menus/qobuz_manager.py
+++ b/src/managers/menus/qobuz_manager.py
@@ -194,6 +194,8 @@ class QobuzManager(BaseManager):
                     }
                     for item in combined_items
                 ]
+                # Append Back option
+                self.current_menu_items.append({"title": "Back", "action": "back"})
                 self.logger.info(f"QobuzManager: Updated menu with {len(self.current_menu_items)} items.")
                 if self.is_active:
                     self.display_menu()
@@ -260,6 +262,10 @@ class QobuzManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"QobuzManager: Selected item: {selected_item}")
+
+        if selected_item.get("action") == "back":
+            self.back()
+            return
 
         uri = selected_item.get("uri")
         if not uri:
@@ -333,6 +339,14 @@ class QobuzManager(BaseManager):
         self.window_start_index = previous_context["window_start_index"]
         self.logger.debug("QobuzManager: Restored previous menu context from stack.")
         self.display_menu()
+
+    def back(self):
+        """Public back interface used by ModeManager or UI."""
+        if self.menu_stack:
+            self.go_back()
+        else:
+            self.stop_mode()
+            super().back()
 
     def handle_toast_message(self, sender, message):
         """Handle toast messages from Volumio, especially errors."""

--- a/src/managers/menus/radio_manager.py
+++ b/src/managers/menus/radio_manager.py
@@ -205,6 +205,7 @@ class RadioManager(BaseManager):
                 item.get("title", item.get("name", "Untitled"))
                 for item in items
             ]
+            self.categories.append("Back")
             self.logger.info(f"RadioManager: Updated categories list with {len(self.categories)} items.")
             self.current_selection_index = 0
             self.window_start_index = 0
@@ -242,6 +243,7 @@ class RadioManager(BaseManager):
                 }
                 for item in items
             ]
+            self.stations.append({"title": "Back", "action": "back"})
             self.logger.info(f"RadioManager: Updated stations list with {len(self.stations)} items.")
             self.current_selection_index = 0
             self.window_start_index = 0
@@ -349,6 +351,9 @@ class RadioManager(BaseManager):
 
         if self.current_menu == "categories":
             selected_category = self.categories[self.current_selection_index]
+            if selected_category == "Back":
+                self.back()
+                return
             self.logger.info(f"RadioManager: Selected radio category: {selected_category}")
 
             # Fetch the URI for the selected category
@@ -372,6 +377,9 @@ class RadioManager(BaseManager):
                 return
 
             selected_station = self.stations[self.current_selection_index]
+            if selected_station.get("title") == "Back":
+                self.back()
+                return
             station_title = selected_station['title'].strip()
             uri = selected_station['uri']
             albumart_url = selected_station.get('albumart', '')
@@ -407,6 +415,14 @@ class RadioManager(BaseManager):
             self.display_categories()
         elif self.current_menu == "stations":
             self.display_radio_stations()
+
+    def back(self):
+        """Public back interface used by ModeManager or UI."""
+        if self.menu_stack:
+            self.navigate_back()
+        else:
+            self.stop_mode()
+            super().back()
 
     def get_visible_window(self, items):
         """Returns a subset of items to display based on the current selection, keeping it centered."""

--- a/src/managers/menus/radioparadise_manager.py
+++ b/src/managers/menus/radioparadise_manager.py
@@ -339,3 +339,8 @@ class RadioParadiseManager(BaseManager):
         except Exception as e:
             self.logger.exception(f"RadioParadiseManager: Failed to play station - {e}")
             self.display_error_message("Playback Error", f"Could not play station: {e}")
+
+    def back(self):
+        """Exit Radio Paradise manager and return to previous mode."""
+        self.stop_mode()
+        super().back()

--- a/src/managers/menus/remote_menu.py
+++ b/src/managers/menus/remote_menu.py
@@ -140,7 +140,7 @@ class RemoteMenu(BaseManager):
         if selected_item == "Back":
             # Return to the previous (config) menu.
             self.stop_mode()
-            self.mode_manager.to_configmenu()
+            self.mode_manager.back()
         else:
             # Define the source directory.
             source_dir = f"/home/volumio/CyFi/lirc/configurations/{selected_item}"

--- a/src/managers/menus/screensaver_menu.py
+++ b/src/managers/menus/screensaver_menu.py
@@ -158,7 +158,7 @@ class ScreensaverMenu(BaseManager):
         if selected_name == "Back":
             # Return to config
             self.stop_mode()
-            self.mode_manager.to_configmenu()
+            self.mode_manager.back()
             return
 
         elif selected_name == "Timer":

--- a/src/managers/menus/spotify_manager.py
+++ b/src/managers/menus/spotify_manager.py
@@ -206,6 +206,8 @@ class SpotifyManager(BaseManager):
             }
             for item in combined_items
         ]
+        # Add Back option
+        self.current_menu_items.append({"title": "Back", "action": "back"})
 
         self.logger.info(f"SpotifyManager: Updated menu with {len(self.current_menu_items)} items.")
 
@@ -265,6 +267,10 @@ class SpotifyManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"SpotifyManager: Selected item: {selected_item}")
+
+        if selected_item.get("action") == "back":
+            self.back()
+            return
 
         uri = selected_item.get("uri")
         if not uri:
@@ -327,6 +333,14 @@ class SpotifyManager(BaseManager):
         self.window_start_index = previous_context["window_start_index"]
         self.logger.debug("SpotifyManager: Restored previous menu context from stack.")
         self.display_menu()
+
+    def back(self):
+        """Public back interface used by ModeManager or UI."""
+        if self.menu_stack:
+            self.go_back()
+        else:
+            self.stop_mode()
+            super().back()
 
     def handle_toast_message(self, sender, message):
         """Handle toast messages from Volumio, especially errors."""

--- a/src/managers/menus/system_update_menu.py
+++ b/src/managers/menus/system_update_menu.py
@@ -143,7 +143,7 @@ class SystemUpdateMenu(BaseManager):
             elif selected_item == "Back":
                 # Return to whichever menu invoked us (maybe config menu)
                 self.stop_mode()
-                self.mode_manager.to_configmenu()
+                self.mode_manager.back()
 
             else:
                 self.logger.warning(f"SystemUpdateMenu: Unknown main item => {selected_item}")

--- a/src/managers/menus/tidal_manager.py
+++ b/src/managers/menus/tidal_manager.py
@@ -221,6 +221,8 @@ class TidalManager(BaseManager):
             }
             for item in combined_items
         ]
+        # Add Back option
+        self.current_menu_items.append({"title": "Back", "action": "back"})
 
         self.logger.info(f"TidalManager: Updated menu with {len(self.current_menu_items)} items.")
 
@@ -281,6 +283,9 @@ class TidalManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"TidalManager: Selected item: {selected_item}")
+        if selected_item.get("action") == "back":
+            self.back()
+            return
         uri = selected_item.get("uri")
 
         if not uri:
@@ -355,6 +360,14 @@ class TidalManager(BaseManager):
         self.window_start_index = previous_context["window_start_index"]
         self.logger.debug("TidalManager: Restored previous menu context from stack.")
         self.display_menu()
+
+    def back(self):
+        """Public back interface used by ModeManager or UI."""
+        if self.menu_stack:
+            self.go_back()
+        else:
+            self.stop_mode()
+            super().back()
 
     def handle_toast_message(self, sender, message, **kwargs):
         """Handle toast messages from Volumio, especially errors."""

--- a/src/managers/menus/usb_library_manager.py
+++ b/src/managers/menus/usb_library_manager.py
@@ -144,6 +144,7 @@ class USBLibraryManager(BaseManager):
             }
             for item in combined_items
         ]
+        self.current_menu_items.append({"title": "Back", "action": "back"})
 
         self.logger.info(f"USBLibraryManager: Updated menu with {len(self.current_menu_items)} items.")
         if self.is_active:
@@ -201,6 +202,10 @@ class USBLibraryManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"USBLibraryManager: Selected menu item: {selected_item}")
+
+        if selected_item.get("action") == "back":
+            self.back()
+            return
 
         name = selected_item.get("title")
         uri = selected_item.get("uri")
@@ -266,3 +271,8 @@ class USBLibraryManager(BaseManager):
             )
 
         self.display_manager.draw_custom(draw)
+
+    def back(self):
+        """Return to previous menu via ModeManager."""
+        self.stop_mode()
+        super().back()

--- a/src/managers/mode_manager.py
+++ b/src/managers/mode_manager.py
@@ -935,7 +935,8 @@ class ModeManager:
                 self.logger.warning("No back mapping for '%s'. Defaulting to clock.", previous_mode)
                 self.to_clock()
         else:
-            self.logger.info("Navigation stack empty, cannot go back.")
+            self.logger.info("Navigation stack empty, returning to main menu.")
+            self.to_menu()
 
     def get_mode(self):
         return self.state


### PR DESCRIPTION
## Summary
- map more IR codes to `back`
- add default `back()` in base managers
- return to menu if navigation stack is empty
- support back action in all menu managers
- append "Back" entries to dynamic menus
- add rotary button handler

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fb668e4b88331ae6d42898b410d95