### PR TITLE
Implement universal Back handling

### DIFF
--- a/src/managers/menus/clock_menu.py
+++ b/src/managers/menus/clock_menu.py
@@ -1,9 +1,9 @@
 import logging
 import time
 from PIL import ImageFont
-from managers.menus.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 
-class ClockMenu(BaseManager):
+class ClockMenu(BaseMenu):
     """
     A scrollable 'Clock' settings menu:
 
@@ -47,20 +47,18 @@ class ClockMenu(BaseManager):
         self.font = display_manager.fonts.get(self.font_key, ImageFont.load_default())
 
         # Main menu
-        self.main_items = [
+        self.main_items = self.ensure_back_item([
             "Show Seconds",
             "Show Date",
             "Select Font",
-            "Back"  # => return to Display Menu
-        ]
+        ])
 
         # Sub-menus
-        # No 'Back' for Show Seconds or Show Date => On/Off only
-        self.seconds_items = ["On", "Off"]
-        self.date_items = ["On", "Off"]
+        self.seconds_items = self.ensure_back_item(["On", "Off"])
+        self.date_items = self.ensure_back_item(["On", "Off"])
 
         # Font sub-menu does include 'Back'
-        self.font_items = ["Sans", "Dots", "Digital", "Bold", "Back"]
+        self.font_items = self.ensure_back_item(["Sans", "Dots", "Digital", "Bold"])
 
         # Current data
         self.current_items = self.main_items
@@ -143,6 +141,9 @@ class ClockMenu(BaseManager):
         selected = self.current_items[self.current_selection_index]
         self.logger.info(f"ClockMenu: Selected => {selected} (menu={self.current_menu})")
 
+        if self.handle_menu_select(self.current_selection_index, self.current_items):
+            return
+
         # MAIN menu
         if self.current_menu == "main":
             if selected == "Show Seconds":
@@ -167,12 +168,6 @@ class ClockMenu(BaseManager):
                 self.current_selection_index = 0
                 self.window_start_index = 0
                 self._draw_current_menu()
-
-            elif selected == "Back":
-                # Return to Display Menu
-                self.logger.info("ClockMenu: 'Back' => to Display Menu")
-                self.stop_mode()
-                self.mode_manager.back()
 
             else:
                 self.logger.warning(f"ClockMenu: Unknown main item => {selected}")
@@ -210,7 +205,7 @@ class ClockMenu(BaseManager):
 
         # SUB-MENU: Fonts => ["Sans", "Dots", "Digital", "Bold", "Back"]
         elif self.current_menu == "fonts":
-            if selected == "Back":
+            if selected == self.back_label:
                 self._return_to_main()
             else:
                 self._handle_font_selection(selected)

--- a/src/managers/menus/config_menu.py
+++ b/src/managers/menus/config_menu.py
@@ -2,9 +2,9 @@ import logging
 import time
 import threading
 from PIL import Image, ImageDraw, ImageFont
-from managers.menus.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 
-class ConfigMenu(BaseManager):
+class ConfigMenu(BaseMenu):
     """
     A configuration menu displayed as a horizontal icon row.
     It matches the style of the MenuManager's icon row menu.
@@ -25,14 +25,13 @@ class ConfigMenu(BaseManager):
         self.bold_font_key = 'menu_font_bold'
 
         # Define config menu items
-        self.menu_items = [
+        self.menu_items = self.ensure_back_item([
             "Display",
             "Clock",
             "Screen+",
             "System",
             "Update",
-            "Back"
-        ]
+        ])
 
         # Map each menu item to an icon.
         # The keys for display_manager.icons should match your asset names.
@@ -159,6 +158,10 @@ class ConfigMenu(BaseManager):
 
         selected = self.menu_items[self.current_index]
         self.logger.info(f"ConfigMenu: Selected {selected}.")
+
+        if self.handle_menu_select(self.current_index, self.menu_items):
+            return
+
         self.stop_mode()
 
         # Trigger the corresponding mode change
@@ -174,7 +177,5 @@ class ConfigMenu(BaseManager):
             self.mode_manager.to_systemupdate()
         elif selected == "IRremote":
             self.mode_manager.to_remotemenu()
-        elif selected == "Back":
-            self.mode_manager.back()
         else:
             self.logger.warning(f"ConfigMenu: Unrecognised selection: {selected}")

--- a/src/managers/menus/display_menu.py
+++ b/src/managers/menus/display_menu.py
@@ -1,9 +1,9 @@
 import logging
 import time
 from PIL import ImageFont
-from managers.menus.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 
-class DisplayMenu(BaseManager):
+class DisplayMenu(BaseMenu):
     """
     A scrollable menu using 'anchored scrolling' (like RadioManager).
 
@@ -52,17 +52,16 @@ class DisplayMenu(BaseManager):
         self.font = display_manager.fonts.get(self.font_key, ImageFont.load_default())
 
         # MAIN menu items
-        self.main_items = [
+        self.main_items = self.ensure_back_item([
             "Display Modes",
             "Spectrum",
             "Brightness",
-            "Back"
-        ]
+        ])
 
         # SUB-menu items (no 'Back' lines here)
-        self.display_modes_items = ["Modern", "Original", "Minimal"]
-        self.spectrum_items      = ["Off", "On"]
-        self.brightness_items    = ["Low", "Medium", "High"]
+        self.display_modes_items = self.ensure_back_item(["Modern", "Original", "Minimal"])
+        self.spectrum_items      = self.ensure_back_item(["Off", "On"])
+        self.brightness_items    = self.ensure_back_item(["Low", "Medium", "High"])
 
         # We'll store whichever list is active in `self.current_list`
         self.current_list = self.main_items
@@ -144,6 +143,9 @@ class DisplayMenu(BaseManager):
             f"DisplayMenu: Selected => {selected_item} in menu '{self.current_menu}'"
         )
 
+        if self.handle_menu_select(self.current_selection_index, self.current_list):
+            return
+
         # MAIN menu logic
         if self.current_menu == "main":
             if selected_item == "Display Modes":
@@ -167,47 +169,56 @@ class DisplayMenu(BaseManager):
                 self.window_start_index = 0
                 self._display_current_menu()
 
-            elif selected_item == "Back":
-                # Return to previous menu
-                self.stop_mode()
-                self.mode_manager.back()
             else:
                 self.logger.warning(f"DisplayMenu: Unknown main item => {selected_item}")
 
         # DISPLAY MODES sub-menu
         elif self.current_menu == "display_modes":
-            # No "Back" item here, so any selection just applies and returns to main
-            self._handle_display_mode(selected_item)
-
-            # After applying, go back to main
-            self.current_menu = "main"
-            self.current_list = self.main_items
-            self.current_selection_index = 0
-            self.window_start_index = 0
-            self._display_current_menu()
+            if selected_item == self.back_label:
+                self.current_menu = "main"
+                self.current_list = self.main_items
+                self.current_selection_index = 0
+                self.window_start_index = 0
+                self._display_current_menu()
+            else:
+                self._handle_display_mode(selected_item)
+                self.current_menu = "main"
+                self.current_list = self.main_items
+                self.current_selection_index = 0
+                self.window_start_index = 0
+                self._display_current_menu()
 
         # SPECTRUM sub-menu
         elif self.current_menu == "spectrum":
-            # No "Back" item here either
-            self._handle_spectrum(selected_item)
-
-            # Return to main
-            self.current_menu = "main"
-            self.current_list = self.main_items
-            self.current_selection_index = 0
-            self.window_start_index = 0
-            self._display_current_menu()
+            if selected_item == self.back_label:
+                self.current_menu = "main"
+                self.current_list = self.main_items
+                self.current_selection_index = 0
+                self.window_start_index = 0
+                self._display_current_menu()
+            else:
+                self._handle_spectrum(selected_item)
+                self.current_menu = "main"
+                self.current_list = self.main_items
+                self.current_selection_index = 0
+                self.window_start_index = 0
+                self._display_current_menu()
 
         # BRIGHTNESS sub-menu
         elif self.current_menu == "brightness":
-            # No "Back" item here
-            self._handle_brightness(selected_item)
-
-            self.current_menu = "main"
-            self.current_list = self.main_items
-            self.current_selection_index = 0
-            self.window_start_index = 0
-            self._display_current_menu()
+            if selected_item == self.back_label:
+                self.current_menu = "main"
+                self.current_list = self.main_items
+                self.current_selection_index = 0
+                self.window_start_index = 0
+                self._display_current_menu()
+            else:
+                self._handle_brightness(selected_item)
+                self.current_menu = "main"
+                self.current_list = self.main_items
+                self.current_selection_index = 0
+                self.window_start_index = 0
+                self._display_current_menu()
 
         else:
             self.logger.warning(f"DisplayMenu: Unrecognized sub-menu => {self.current_menu}")

--- a/src/managers/menus/library_manager.py
+++ b/src/managers/menus/library_manager.py
@@ -10,9 +10,9 @@ from requests.adapters import HTTPAdapter
 from urllib.parse import quote
 from urllib3.util.retry import Retry
 from PIL import Image, ImageDraw, ImageFont
-from managers.base_manager import BaseManager  # Adjust import based on your project structure
+from managers.menus.base_manager import BaseMenu
 
-class LibraryManager(BaseManager):
+class LibraryManager(BaseMenu):
     def __init__(self, display_manager, volumio_config, mode_manager, window_size=3, y_offset=0, line_spacing=16):
         super().__init__(display_manager, volumio_config, mode_manager)
 
@@ -189,7 +189,7 @@ class LibraryManager(BaseManager):
                 for item in items
             ]
             # Append a Back option for consistent navigation
-            self.current_menu_items.append({"title": "Back", "action": "back"})
+            self.current_menu_items = self.ensure_back_item(self.current_menu_items)
 
             self.logger.info(f"LibraryManager: Fetched {len(self.current_menu_items)} items for URI: {uri}")
             if self.is_active:
@@ -210,6 +210,9 @@ class LibraryManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"LibraryManager: Selected item: {selected_item}")
+
+        if self.handle_menu_select(self.current_selection_index, self.current_menu_items):
+            return
 
         if 'action' in selected_item:
             # Handle submenu actions
@@ -281,11 +284,10 @@ class LibraryManager(BaseManager):
         self.logger.info(f"LibraryManager: Displaying options for album: {folder_item.get('title')}")
 
         # Define the submenu with icons
-        options = [
+        options = self.ensure_back_item([
             {"title": "Play Album", "action": "play_album", "data": folder_item, "icon": "play"},
             {"title": "Select Songs", "action": "select_songs", "data": folder_item, "icon": "songs"},
-            {"title": "Back", "action": "back", "icon": "back"}
-        ]
+        ])
 
         # Push the options menu onto the stack
         self.push_menu(options, menu_title=f"Album: {folder_item.get('title')}")

--- a/src/managers/menus/playlist_manager.py
+++ b/src/managers/menus/playlist_manager.py
@@ -1,9 +1,9 @@
-from managers.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 import logging
 from PIL import ImageFont
 import threading
 
-class PlaylistManager(BaseManager):
+class PlaylistManager(BaseMenu):
     def __init__(self, display_manager, volumio_listener, mode_manager, window_size=4, y_offset=5, line_spacing=15):
         super().__init__(display_manager, volumio_listener, mode_manager)
         self.mode_name = "playlists"
@@ -154,7 +154,7 @@ class PlaylistManager(BaseManager):
             }
             for item in combined_items
         ]
-        self.current_menu_items.append({"title": "Back", "action": "back"})
+        self.current_menu_items = self.ensure_back_item(self.current_menu_items)
 
         self.logger.info(f"PlaylistManager: Updated menu with {len(self.current_menu_items)} items.")
         if self.is_active:
@@ -237,8 +237,8 @@ class PlaylistManager(BaseManager):
             return
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"PlaylistManager: Selected item: {selected_item}")
-        if selected_item.get("action") == "back":
-            self.back()
+
+        if self.handle_menu_select(self.current_selection_index, self.current_menu_items):
             return
         name = selected_item.get("title")
         if not name:

--- a/src/managers/menus/qobuz_manager.py
+++ b/src/managers/menus/qobuz_manager.py
@@ -1,11 +1,11 @@
 # src/managers/qobuz_manager.py
-from managers.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 import logging
 from PIL import ImageFont
 import threading
 import time
 
-class QobuzManager(BaseManager):
+class QobuzManager(BaseMenu):
     def __init__(self, display_manager, volumio_listener, mode_manager, window_size=4, y_offset=5, line_spacing=15):
         super().__init__(display_manager, volumio_listener, mode_manager)
         self.mode_name = "qobuz"
@@ -194,8 +194,7 @@ class QobuzManager(BaseManager):
                     }
                     for item in combined_items
                 ]
-                # Append Back option
-                self.current_menu_items.append({"title": "Back", "action": "back"})
+                self.current_menu_items = self.ensure_back_item(self.current_menu_items)
                 self.logger.info(f"QobuzManager: Updated menu with {len(self.current_menu_items)} items.")
                 if self.is_active:
                     self.display_menu()
@@ -263,8 +262,7 @@ class QobuzManager(BaseManager):
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"QobuzManager: Selected item: {selected_item}")
 
-        if selected_item.get("action") == "back":
-            self.back()
+        if self.handle_menu_select(self.current_selection_index, self.current_menu_items):
             return
 
         uri = selected_item.get("uri")

--- a/src/managers/menus/radio_manager.py
+++ b/src/managers/menus/radio_manager.py
@@ -1,13 +1,13 @@
 # src/managers/radio_manager.py
 
-from managers.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 import logging
 from PIL import ImageFont
 import threading
 import time
 
 
-class RadioManager(BaseManager):
+class RadioManager(BaseMenu):
     def __init__(self, display_manager, volumio_listener, mode_manager, window_size=4, y_offset=2, line_spacing=15):
         super().__init__(display_manager, volumio_listener, mode_manager)
 
@@ -205,7 +205,7 @@ class RadioManager(BaseManager):
                 item.get("title", item.get("name", "Untitled"))
                 for item in items
             ]
-            self.categories.append("Back")
+            self.categories = self.ensure_back_item(self.categories)
             self.logger.info(f"RadioManager: Updated categories list with {len(self.categories)} items.")
             self.current_selection_index = 0
             self.window_start_index = 0
@@ -243,7 +243,7 @@ class RadioManager(BaseManager):
                 }
                 for item in items
             ]
-            self.stations.append({"title": "Back", "action": "back"})
+            self.stations = self.ensure_back_item(self.stations)
             self.logger.info(f"RadioManager: Updated stations list with {len(self.stations)} items.")
             self.current_selection_index = 0
             self.window_start_index = 0
@@ -351,8 +351,7 @@ class RadioManager(BaseManager):
 
         if self.current_menu == "categories":
             selected_category = self.categories[self.current_selection_index]
-            if selected_category == "Back":
-                self.back()
+            if self.handle_menu_select(self.current_selection_index, self.categories):
                 return
             self.logger.info(f"RadioManager: Selected radio category: {selected_category}")
 
@@ -377,8 +376,7 @@ class RadioManager(BaseManager):
                 return
 
             selected_station = self.stations[self.current_selection_index]
-            if selected_station.get("title") == "Back":
-                self.back()
+            if self.handle_menu_select(self.current_selection_index, self.stations):
                 return
             station_title = selected_station['title'].strip()
             uri = selected_station['uri']

--- a/src/managers/menus/remote_menu.py
+++ b/src/managers/menus/remote_menu.py
@@ -3,10 +3,10 @@ import time
 import os
 import subprocess
 from PIL import ImageFont
-from managers.menus.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 import sys
 
-class RemoteMenu(BaseManager):
+class RemoteMenu(BaseMenu):
     """
     A scrollable menu for selecting and installing an IR remote configuration.
     
@@ -66,8 +66,8 @@ class RemoteMenu(BaseManager):
             "Yamaha RAV363"
         ]
         
-        # Append a "Back" option to allow the user to exit.
-        self.current_list = self.remote_options + ["Back"]
+        # Append a "Back" option automatically
+        self.current_list = self.ensure_back_item(self.remote_options)
         self.current_selection_index = 0
 
     # ----------------------------------------------------------------
@@ -137,10 +137,8 @@ class RemoteMenu(BaseManager):
         selected_item = self.current_list[self.current_selection_index]
         self.logger.info(f"RemoteMenu: Selected => {selected_item}")
 
-        if selected_item == "Back":
-            # Return to the previous (config) menu.
-            self.stop_mode()
-            self.mode_manager.back()
+        if self.handle_menu_select(self.current_selection_index, self.current_list):
+            return
         else:
             # Define the source directory.
             source_dir = f"/home/volumio/CyFi/lirc/configurations/{selected_item}"

--- a/src/managers/menus/spotify_manager.py
+++ b/src/managers/menus/spotify_manager.py
@@ -1,10 +1,10 @@
 # src/managers/spotify_manager.py
-from managers.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 import logging
 from PIL import ImageFont
 import threading
 
-class SpotifyManager(BaseManager):
+class SpotifyManager(BaseMenu):
     def __init__(self, display_manager, volumio_listener, mode_manager, window_size=4, y_offset=5, line_spacing=15):
         super().__init__(display_manager, volumio_listener, mode_manager)
         self.mode_name = "spotify"
@@ -206,8 +206,7 @@ class SpotifyManager(BaseManager):
             }
             for item in combined_items
         ]
-        # Add Back option
-        self.current_menu_items.append({"title": "Back", "action": "back"})
+        self.current_menu_items = self.ensure_back_item(self.current_menu_items)
 
         self.logger.info(f"SpotifyManager: Updated menu with {len(self.current_menu_items)} items.")
 
@@ -268,8 +267,7 @@ class SpotifyManager(BaseManager):
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"SpotifyManager: Selected item: {selected_item}")
 
-        if selected_item.get("action") == "back":
-            self.back()
+        if self.handle_menu_select(self.current_selection_index, self.current_menu_items):
             return
 
         uri = selected_item.get("uri")

--- a/src/managers/menus/system_update_menu.py
+++ b/src/managers/menus/system_update_menu.py
@@ -2,9 +2,9 @@ import logging
 import time
 import subprocess
 from PIL import ImageFont
-from managers.menus.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 
-class SystemUpdateMenu(BaseManager):
+class SystemUpdateMenu(BaseMenu):
     """
     A scrollable menu for handling "System Update" interactions:
       - Main menu:
@@ -44,13 +44,12 @@ class SystemUpdateMenu(BaseManager):
         self.font = display_manager.fonts.get(self.font_key, ImageFont.load_default())
 
         # MAIN menu items
-        self.main_items = [
+        self.main_items = self.ensure_back_item([
             "Update from GitHub",
-            "Back"
-        ]
+        ])
 
         # CONFIRM sub-menu
-        self.confirm_items = ["Yes", "No"]
+        self.confirm_items = self.ensure_back_item(["Yes", "No"])
 
         # We'll store whichever list is active in `self.current_list`
         self.current_list = self.main_items
@@ -131,6 +130,9 @@ class SystemUpdateMenu(BaseManager):
             f"SystemUpdateMenu: Selected => {selected_item} in menu '{self.current_menu}'"
         )
 
+        if self.handle_menu_select(self.current_selection_index, self.current_list):
+            return
+
         if self.current_menu == "main":
             if selected_item == "Update from GitHub":
                 # Jump to confirm sub-menu
@@ -139,11 +141,6 @@ class SystemUpdateMenu(BaseManager):
                 self.current_selection_index = 0
                 self.window_start_index = 0
                 self._display_current_menu()
-
-            elif selected_item == "Back":
-                # Return to whichever menu invoked us (maybe config menu)
-                self.stop_mode()
-                self.mode_manager.back()
 
             else:
                 self.logger.warning(f"SystemUpdateMenu: Unknown main item => {selected_item}")

--- a/src/managers/menus/tidal_manager.py
+++ b/src/managers/menus/tidal_manager.py
@@ -1,12 +1,12 @@
 # src/managers/tidal_manager.py
 
-from managers.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 import logging
 from PIL import ImageFont
 import threading
 import time
 
-class TidalManager(BaseManager):
+class TidalManager(BaseMenu):
     def __init__(self, display_manager, volumio_listener, mode_manager, window_size=4, y_offset=2, line_spacing=15):
         super().__init__(display_manager, volumio_listener, mode_manager)
         self.mode_name = "tidal"
@@ -221,8 +221,7 @@ class TidalManager(BaseManager):
             }
             for item in combined_items
         ]
-        # Add Back option
-        self.current_menu_items.append({"title": "Back", "action": "back"})
+        self.current_menu_items = self.ensure_back_item(self.current_menu_items)
 
         self.logger.info(f"TidalManager: Updated menu with {len(self.current_menu_items)} items.")
 
@@ -283,8 +282,8 @@ class TidalManager(BaseManager):
 
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"TidalManager: Selected item: {selected_item}")
-        if selected_item.get("action") == "back":
-            self.back()
+
+        if self.handle_menu_select(self.current_selection_index, self.current_menu_items):
             return
         uri = selected_item.get("uri")
 

--- a/src/managers/menus/usb_library_manager.py
+++ b/src/managers/menus/usb_library_manager.py
@@ -1,11 +1,11 @@
 # usb_library_manager.py
 
-from managers.base_manager import BaseManager
+from managers.menus.base_manager import BaseMenu
 import logging
 from PIL import ImageFont
 import threading
 
-class USBLibraryManager(BaseManager):
+class USBLibraryManager(BaseMenu):
     def __init__(self, display_manager, volumio_listener, mode_manager, window_size=4, y_offset=5, line_spacing=15):
         super().__init__(display_manager, volumio_listener, mode_manager)
         self.mode_name = "usblibrary"
@@ -144,7 +144,7 @@ class USBLibraryManager(BaseManager):
             }
             for item in combined_items
         ]
-        self.current_menu_items.append({"title": "Back", "action": "back"})
+        self.current_menu_items = self.ensure_back_item(self.current_menu_items)
 
         self.logger.info(f"USBLibraryManager: Updated menu with {len(self.current_menu_items)} items.")
         if self.is_active:
@@ -203,8 +203,7 @@ class USBLibraryManager(BaseManager):
         selected_item = self.current_menu_items[self.current_selection_index]
         self.logger.info(f"USBLibraryManager: Selected menu item: {selected_item}")
 
-        if selected_item.get("action") == "back":
-            self.back()
+        if self.handle_menu_select(self.current_selection_index, self.current_menu_items):
             return
 
         name = selected_item.get("title")


### PR DESCRIPTION
## Summary
- introduce `BaseMenu` with automatic Back handling
- refactor all menu classes to inherit from `BaseMenu`
- ensure Back option is appended via `ensure_back_item`
- route selection through `handle_menu_select`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fba9d71308331aa5d6306ad0482bf